### PR TITLE
NFA: Support Epsilon NFA

### DIFF
--- a/example/nfa_example.dart
+++ b/example/nfa_example.dart
@@ -10,26 +10,28 @@ void main() {
       states: {"q0", "q1", "q2"},
       transitionFunction: {
         "q0": {
-          "0": {"q1"}
+          "0": {"q1"},
+          "": {"q1"}
         },
         "q1": {
-          "1": {"q2"}
+          "0": {"q2"},
+          "": {"q2"}
         },
         "q2": {
           "0": {"q2"},
-          "1": {"q2"}
+          "": {"q0"}
         }
       });
 
   print("Is NFA valid? ${nfa.validate()}");
-
+  print(nfa.epsilonClosure);
   String? inputString;
   print("Test a input string");
   inputString = stdin.readLineSync();
 
-  if (inputString == null)
+  if (inputString == null) {
     return;
-  else {
+  } else {
     print(nfa.testInput(inputString.split("")));
   }
 }


### PR DESCRIPTION
Add epsilon closure for states. Using this epsilon closure we can find
all the states that we visit while transitioning. So this also fixes the
transition function and which fixes the input taking.

Currently epsilon is denoted by an empty string
